### PR TITLE
Security: Do not reset failure counter on successfull login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/config.inc.php

--- a/rcguard.php
+++ b/rcguard.php
@@ -116,7 +116,7 @@ class rcguard extends rcube_plugin
   {
     $client_ip = rcube_utils::remote_addr();
 
-    $this->delete_rcguard('', $client_ip, true);
+//    $this->delete_rcguard('', $client_ip, true);
 
     return $args;
   }


### PR DESCRIPTION
Hi,

this pull request removes the failure counter reset upon successfull logins.
Any user with a valid account could abuse this feature to do a bruteforce attack on other accounts.

Example:
- (Configuration allows 5 attempts until captcha is shown)
- (The are two active accounts, Alice and Chuck)
- Chuck makes 4 tries to guess the password for Alice, but fails
- Chuck now login with his credentials, the counter resets
- Chuck can now issue another 4 attempts and so on

Within this pull request is also gitignore for the (user made) config.inc.php, I almost accidently commited mine.

Regards,
Simon
